### PR TITLE
NeoForge death event cancellation handling

### DIFF
--- a/src/main/java/dev/leo/sableplayerragdoll/neoforge/SablePlayerRagdollNeoForge.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/neoforge/SablePlayerRagdollNeoForge.java
@@ -1007,7 +1007,7 @@ public final class SablePlayerRagdollNeoForge {
    }
 
    private static void onPlayerDeath(LivingDeathEvent event) {
-      if (!(event.getEntity() instanceof ServerPlayer player)) return;
+      if (event.isCanceled() || !(event.getEntity() instanceof ServerPlayer player)) return;
       ServerLevel level = player.serverLevel();
       ServerSubLevel ragdoll = RagdollSessionManager.activeRagdollForPlayer(level, player.getUUID());
       if (ragdoll == null) return;


### PR DESCRIPTION
Currently cancelled death events are not being handled correctly - mods can cancel entity death event and implement some custom logic, but this mod still assumes that the player always dies.
This PR adds simple `event.isCanceled` check which solves these issues