### PR TITLE
[WIP] Implement mod compatibility for rendering items from the Cosmetic Armor mod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,16 @@ crash-reports/
 .DS_Store
 Thumbs.db
 bin/
+
+# MixinMCP auto-injected rules
+.cursor/rules/minecraft-mod-project.mdc
+.cursor/skills/mixin-writing/SKILL.md
+.cursor/skills/mixin-writing/references/at-reference.md
+.cursor/skills/mixin-writing/references/expressions-language.md
+.cursor/skills/mixinmcp-tools/SKILL.md
+.cursor/skills/mixinmcp-tools/references/toolchains.md
+.claude/skills/mixin-writing/SKILL.md
+.claude/skills/mixin-writing/references/at-reference.md
+.claude/skills/mixin-writing/references/expressions-language.md
+.claude/skills/mixinmcp-tools/SKILL.md
+.claude/skills/mixinmcp-tools/references/toolchains.md

--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,10 @@ dependencies {
 
     compileOnly("io.wispforest:accessories-neoforge:${accessories_version}") { transitive = false }
 
+    compileOnly("maven.modrinth:cosmetic-armor-reworked-forked:${cosmeticarmor_version}") { transitive = false }
+
     compileOnly("maven.modrinth:jade:${jade_version}")
+
 
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,6 +32,9 @@ sable_mod_version=1.1.0
 curios_version=9.5.1+1.21.1
 accessories_version=1.1.0-beta.53+1.21.1
 jade_version=15.10.5+neoforge
+    # 1.21.1-0.0.4
+    # ^ This is the version id in fabric, the neoforge version id isn't showing up for me.
+cosmeticarmor_version=U6kExSSz
 
 # Gradle
 org.gradle.jvmargs=-Xmx4G

--- a/src/main/java/dev/leo/sableplayerragdoll/api/RagdollEquipmentSnapshot.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/api/RagdollEquipmentSnapshot.java
@@ -16,8 +16,8 @@ public record RagdollEquipmentSnapshot(
    Map<String, List<ItemStack>> accessoriesItems,
    Map<String, List<ItemStack>> accessoriesCosmeticItems,
    Map<String, List<Boolean>> accessoriesRenderOptions,
+
    // PR - Cosmetic Armor mod support
-   // TODO: learn how to render these
    Map<String, List<ItemStack>> cosmeticArmorItems,
    Map<String, List<Boolean>> cosmeticArmorRenderOptions
 ) {

--- a/src/main/java/dev/leo/sableplayerragdoll/api/RagdollEquipmentSnapshot.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/api/RagdollEquipmentSnapshot.java
@@ -15,14 +15,24 @@ public record RagdollEquipmentSnapshot(
    Map<String, List<Boolean>> curioRenderOptions,
    Map<String, List<ItemStack>> accessoriesItems,
    Map<String, List<ItemStack>> accessoriesCosmeticItems,
-   Map<String, List<Boolean>> accessoriesRenderOptions
+   Map<String, List<Boolean>> accessoriesRenderOptions,
+   // PR - Cosmetic Armor mod support
+   // TODO: learn how to render these
+   Map<String, List<ItemStack>> cosmeticArmorItems,
+   Map<String, List<Boolean>> cosmeticArmorRenderOptions
 ) {
    public RagdollEquipmentSnapshot(
       Map<EquipmentSlot, ItemStack> vanillaItems,
       Map<String, List<ItemStack>> curioItems,
-      Map<String, List<ItemStack>> accessoriesItems
+      Map<String, List<ItemStack>> accessoriesItems,
+      Map<String, List<ItemStack>> cosmeticArmorItems
    ) {
-      this(vanillaItems, curioItems, Map.of(), Map.of(), accessoriesItems, Map.of(), Map.of());
+      this(
+              vanillaItems,
+              curioItems, Map.of(), Map.of(),
+              accessoriesItems, Map.of(), Map.of(),
+              cosmeticArmorItems, Map.of()
+      );
    }
 
    public RagdollEquipmentSnapshot {
@@ -36,7 +46,7 @@ public record RagdollEquipmentSnapshot(
    }
 
    public static RagdollEquipmentSnapshot empty() {
-      return new RagdollEquipmentSnapshot(Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), Map.of());
+      return new RagdollEquipmentSnapshot(Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), Map.of());
    }
 
    public RagdollEquipmentSnapshot merge(RagdollEquipmentSnapshot other) {
@@ -70,7 +80,20 @@ public record RagdollEquipmentSnapshot(
       accessoryRenderOptions.putAll(this.accessoriesRenderOptions);
       accessoryRenderOptions.putAll(other.accessoriesRenderOptions);
 
-      return new RagdollEquipmentSnapshot(vanilla, curios, curioCosmetics, curioRenderOptions, accessories, accessoryCosmetics, accessoryRenderOptions);
+      Map<String, List<ItemStack>> cosmeticArmors = new LinkedHashMap<>();
+      accessoryCosmetics.putAll(this.cosmeticArmorItems);
+      accessoryCosmetics.putAll(other.cosmeticArmorItems);
+
+      Map<String, List<Boolean>> cosmeticArmorRenderOptions = new LinkedHashMap<>();
+      accessoryRenderOptions.putAll(this.cosmeticArmorRenderOptions);
+      accessoryRenderOptions.putAll(other.cosmeticArmorRenderOptions);
+
+      return new RagdollEquipmentSnapshot(
+              vanilla,
+              curios, curioCosmetics, curioRenderOptions,
+              accessories, accessoryCosmetics, accessoryRenderOptions,
+              cosmeticArmors, cosmeticArmorRenderOptions
+      );
    }
 
    public boolean isEmpty() {
@@ -80,7 +103,9 @@ public record RagdollEquipmentSnapshot(
          && curioRenderOptions.isEmpty()
          && accessoriesItems.isEmpty()
          && accessoriesCosmeticItems.isEmpty()
-         && accessoriesRenderOptions.isEmpty();
+         && accessoriesRenderOptions.isEmpty()
+         && cosmeticArmorItems.isEmpty()
+         && cosmeticArmorRenderOptions.isEmpty();
    }
 
    public RagdollEquipmentSnapshot filteredByAvailableItems(List<ItemStack> availableItems) {
@@ -101,7 +126,14 @@ public record RagdollEquipmentSnapshot(
       Map<String, List<ItemStack>> curioCosmetics = filterSlotMapLoose(curioCosmeticItems, available);
       Map<String, List<ItemStack>> accessories = filterSlotMapLoose(accessoriesItems, available);
       Map<String, List<ItemStack>> accessoryCosmetics = filterSlotMapLoose(accessoriesCosmeticItems, available);
-      return new RagdollEquipmentSnapshot(vanilla, curios, curioCosmetics, curioRenderOptions, accessories, accessoryCosmetics, accessoriesRenderOptions);
+      Map<String, List<ItemStack>> cosmeticArmors = filterSlotMapLoose(cosmeticArmorItems, available);
+
+      return new RagdollEquipmentSnapshot(
+              vanilla,
+              curios, curioCosmetics, curioRenderOptions,
+              accessories, accessoryCosmetics, accessoriesRenderOptions,
+              cosmeticArmors, cosmeticArmorRenderOptions
+      );
    }
 
    private static Map<EquipmentSlot, ItemStack> copyVanilla(Map<EquipmentSlot, ItemStack> source) {

--- a/src/main/java/dev/leo/sableplayerragdoll/block/entity/RagdollPartBlockEntity.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/block/entity/RagdollPartBlockEntity.java
@@ -73,6 +73,8 @@ public final class RagdollPartBlockEntity extends BlockEntity implements BlockEn
    private Map<String, List<ItemStack>> accessoriesItems = new LinkedHashMap<>();
    private Map<String, List<ItemStack>> accessoriesCosmeticItems = new LinkedHashMap<>();
    private Map<String, List<Boolean>> accessoriesRenderOptions = new LinkedHashMap<>();
+   private Map<String, List<ItemStack>> cosmeticArmorItems = new LinkedHashMap<>();
+   private Map<String, List<Boolean>> cosmeticArmorsRenderOptions = new LinkedHashMap<>();
    private final Map<UUID, GrabConstraint> grabbers = new HashMap<>();
 
    public RagdollPartBlockEntity(BlockPos pos, BlockState state) {
@@ -307,6 +309,14 @@ public final class RagdollPartBlockEntity extends BlockEntity implements BlockEn
       }
       this.setChanged();
    }
+   public void setCosmeticArmorRenderOptions(String slotName, List<Boolean> options) {
+      if (options == null || options.isEmpty()) {
+         this.cosmeticArmorsRenderOptions.remove(slotName);
+      } else {
+         this.cosmeticArmorsRenderOptions.put(slotName, List.copyOf(options));
+      }
+      this.setChanged();
+   }
 
    public Map<String, List<ItemStack>> getAccessoriesItems() {
       return Collections.unmodifiableMap(this.accessoriesItems);
@@ -319,9 +329,16 @@ public final class RagdollPartBlockEntity extends BlockEntity implements BlockEn
    public Map<String, List<Boolean>> getAccessoriesRenderOptions() {
       return Collections.unmodifiableMap(this.accessoriesRenderOptions);
    }
+   public Map<String, List<Boolean>> getCosmeticArmorsRenderOptions() {
+      return Collections.unmodifiableMap(this.cosmeticArmorsRenderOptions);
+   }
 
    public boolean hasAccessoriesItems() {
       return !this.accessoriesItems.isEmpty() || !this.accessoriesCosmeticItems.isEmpty() || !this.accessoriesRenderOptions.isEmpty();
+   }
+
+   public boolean hasCosmeticArmor() {
+      return !this.cosmeticArmorsRenderOptions.isEmpty() || !this.cosmeticArmorItems.isEmpty();
    }
 
    @Override
@@ -349,6 +366,8 @@ public final class RagdollPartBlockEntity extends BlockEntity implements BlockEn
       if (!this.accessoriesItems.isEmpty()) tag.put("AccessoriesItems", saveSlotMap(this.accessoriesItems, registries));
       if (!this.accessoriesCosmeticItems.isEmpty()) tag.put("AccessoriesCosmeticItems", saveSlotMap(this.accessoriesCosmeticItems, registries));
       if (!this.accessoriesRenderOptions.isEmpty()) tag.put("AccessoriesRenderOptions", saveBooleanSlotMap(this.accessoriesRenderOptions));
+      if (!this.cosmeticArmorItems.isEmpty()) tag.put("CosmeticArmorItems", saveSlotMap(this.cosmeticArmorItems, registries));
+      if (!this.cosmeticArmorsRenderOptions.isEmpty()) tag.put("CosArmorRenderOptions", saveBooleanSlotMap(this.cosmeticArmorsRenderOptions));
    }
 
    @Override
@@ -373,6 +392,8 @@ public final class RagdollPartBlockEntity extends BlockEntity implements BlockEn
       loadSlotMap(tag, registries, "AccessoriesItems", this.accessoriesItems);
       loadSlotMap(tag, registries, "AccessoriesCosmeticItems", this.accessoriesCosmeticItems);
       loadBooleanSlotMap(tag, "AccessoriesRenderOptions", this.accessoriesRenderOptions);
+      loadSlotMap(tag, registries, "CosmeticArmorItems", this.cosmeticArmorItems);
+      loadBooleanSlotMap(tag, "CosArmorRenderOptions", this.cosmeticArmorsRenderOptions);
    }
 
    @Override

--- a/src/main/java/dev/leo/sableplayerragdoll/block/entity/RagdollPartBlockEntity.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/block/entity/RagdollPartBlockEntity.java
@@ -312,9 +312,9 @@ public final class RagdollPartBlockEntity extends BlockEntity implements BlockEn
 
    public void setCosmeticArmorItems(String slotName, List<ItemStack> stacks) {
       if (stacks == null || stacks.stream().allMatch(ItemStack::isEmpty)) {
-         this.accessoriesCosmeticItems.remove(slotName);
+         this.cosmeticArmorItems.remove(slotName);
       } else {
-         this.accessoriesCosmeticItems.put(slotName, Collections.unmodifiableList(new ArrayList<>(stacks)));
+         this.cosmeticArmorItems.put(slotName, Collections.unmodifiableList(new ArrayList<>(stacks)));
       }
       this.setChanged();
    }

--- a/src/main/java/dev/leo/sableplayerragdoll/block/entity/RagdollPartBlockEntity.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/block/entity/RagdollPartBlockEntity.java
@@ -329,6 +329,9 @@ public final class RagdollPartBlockEntity extends BlockEntity implements BlockEn
    public Map<String, List<Boolean>> getAccessoriesRenderOptions() {
       return Collections.unmodifiableMap(this.accessoriesRenderOptions);
    }
+   public Map<String, List<ItemStack>> getCosmeticArmorItems() {
+      return Collections.unmodifiableMap(this.cosmeticArmorItems);
+   }
    public Map<String, List<Boolean>> getCosmeticArmorsRenderOptions() {
       return Collections.unmodifiableMap(this.cosmeticArmorsRenderOptions);
    }

--- a/src/main/java/dev/leo/sableplayerragdoll/block/entity/RagdollPartBlockEntity.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/block/entity/RagdollPartBlockEntity.java
@@ -309,6 +309,15 @@ public final class RagdollPartBlockEntity extends BlockEntity implements BlockEn
       }
       this.setChanged();
    }
+
+   public void setCosmeticArmorItems(String slotName, List<ItemStack> stacks) {
+      if (stacks == null || stacks.stream().allMatch(ItemStack::isEmpty)) {
+         this.accessoriesCosmeticItems.remove(slotName);
+      } else {
+         this.accessoriesCosmeticItems.put(slotName, Collections.unmodifiableList(new ArrayList<>(stacks)));
+      }
+      this.setChanged();
+   }
    public void setCosmeticArmorRenderOptions(String slotName, List<Boolean> options) {
       if (options == null || options.isEmpty()) {
          this.cosmeticArmorsRenderOptions.remove(slotName);

--- a/src/main/java/dev/leo/sableplayerragdoll/neoforge/client/AccessoriesRenderHelper.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/neoforge/client/AccessoriesRenderHelper.java
@@ -41,7 +41,7 @@ final class AccessoriesRenderHelper {
         Map.entry("wrist",    Set.of(BodyPart.LEFT_ARM, BodyPart.RIGHT_ARM))
     );
 
-    //f irst match wins.
+    // first match wins.
     private record KeywordRule(String keyword, Set<BodyPart> parts) {}
     private static final List<KeywordRule> SLOT_KEYWORDS = List.of(
         // Head

--- a/src/main/java/dev/leo/sableplayerragdoll/neoforge/client/CosArmorRenderHelper.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/neoforge/client/CosArmorRenderHelper.java
@@ -129,7 +129,7 @@ final class CosArmorRenderHelper {
         try {
             ((Player)entity).getInventory().armor.set(slot, cosStack);
             if (layer instanceof HumanoidArmorLayerAccessor accessor) {
-                accessor.renderPlayerArmor(poseStack, buffer, entity, equipmentSlot, packedLight, accessor.accessPlayerModel());
+                accessor.renderPlayerArmor(poseStack, buffer, entity, equipmentSlot, packedLight, accessor.accessPlayerModel(equipmentSlot));
             }
         } finally {
             ((Player)entity).getInventory().armor.set(slot, originalStack);

--- a/src/main/java/dev/leo/sableplayerragdoll/neoforge/client/CosArmorRenderHelper.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/neoforge/client/CosArmorRenderHelper.java
@@ -1,0 +1,307 @@
+package dev.leo.sableplayerragdoll.neoforge.client;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.mojang.blaze3d.vertex.PoseStack;
+import dev.leo.sableplayerragdoll.block.entity.RagdollPartBlockEntity;
+import dev.leo.sableplayerragdoll.block.entity.RagdollPartBlockEntity.BodyPart;
+import dev.leo.sableplayerragdoll.entity.RagdollDollEntity;
+import io.wispforest.accessories.api.AccessoriesCapability;
+import io.wispforest.accessories.api.AccessoriesContainer;
+import io.wispforest.accessories.api.client.AccessoriesRendererRegistry;
+import io.wispforest.accessories.api.client.AccessoryRenderer;
+import io.wispforest.accessories.api.slot.SlotReference;
+import io.wispforest.accessories.api.slot.SlotTypeReference;
+import io.wispforest.accessories.menu.ArmorSlotTypes;
+import lain.mods.cos.impl.InventoryManager;
+import lain.mods.cos.impl.ModConfigs;
+import lain.mods.cos.impl.ModObjects;
+import lain.mods.cos.impl.client.InventoryManagerClient;
+import lain.mods.cos.impl.client.PlayerRenderHandler;
+import lain.mods.cos.impl.inventory.InventoryCosArmor;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.model.PlayerModel;
+import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.RenderLayerParent;
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+final class CosArmorRenderHelper {
+
+    private CosArmorRenderHelper() {}
+
+    @Nullable
+    static ItemStack storedCosmeticArmorOverride(RagdollPartBlockEntity blockEntity, EquipmentSlot slot) {
+        SlotTypeReference reference = ArmorSlotTypes.getReferenceFromSlot(slot);
+        if (reference == null) return null;
+        String slotName = reference.slotName();
+        if (!storedShouldRender(blockEntity, slotName, 0)) return ItemStack.EMPTY;
+        List<ItemStack> cosmeticItems = blockEntity.getAccessoriesCosmeticItems().get(slotName);
+        if (cosmeticItems == null || cosmeticItems.isEmpty()) return null;
+        ItemStack item = cosmeticItems.get(0);
+        return item.isEmpty() ? null : item;
+    }
+
+    @Nullable
+    static ItemStack cosmeticArmorOverride(LivingEntity entity, EquipmentSlot slot) {
+        var inv = ModObjects.invMan.getCosArmorInventoryClient(entity.getUUID());
+        if (inv == null) return null;
+
+        if (inv.isSkinArmor(slot.getIndex())) return ItemStack.EMPTY;
+
+        ItemStack cosmetic = inv.getItem(slot.getIndex());
+        return cosmetic.isEmpty() ? null : cosmetic;
+    }
+
+    @Nullable
+    private static ModelPart oppositeLimb(BodyPart bodyPart, PlayerModel<?> model) {
+        return switch (bodyPart) {
+            case LEFT_LEG  -> model.rightLeg;
+            case RIGHT_LEG -> model.leftLeg;
+            case LEFT_ARM  -> model.rightArm;
+            case RIGHT_ARM -> model.leftArm;
+            default -> null;
+        };
+    }
+
+    static void renderFromStored(
+        BodyPart bodyPart,
+        RagdollPartBlockEntity blockEntity,
+        LivingEntity entity,
+        RenderLayerParent<RagdollDollEntity, PlayerModel<RagdollDollEntity>> parent,
+        PoseStack poseStack,
+        MultiBufferSource buffer,
+        int packedLight,
+        float partialTick
+    ) {
+        PlayerModel<RagdollDollEntity> model = parent.getModel();
+        ModelPart offLimb = oppositeLimb(bodyPart, model);
+
+        for (String slotName : storedSlotNames(blockEntity)) {
+            if (ArmorSlotTypes.isArmorType(slotName)) continue;
+            List<ItemStack> stacks = blockEntity.getAccessoriesItems().getOrDefault(slotName, List.of());
+            List<ItemStack> cosmetics = blockEntity.getAccessoriesCosmeticItems().getOrDefault(slotName, List.of());
+            int slots = Math.max(stacks.size(), cosmetics.size());
+            for (int i = 0; i < slots; i++) {
+                if (!storedShouldRender(blockEntity, slotName, i)) continue;
+                ItemStack stack = storedEffectiveStack(cosmetics, i, storedStack(stacks, i));
+                if (stack.isEmpty()) continue;
+                AccessoryRenderer renderer = AccessoriesRendererRegistry.getRenderer(stack);
+                if (renderer.isEmpty() || !renderer.shouldRender(true)) continue;
+
+                float offLimbY = 0.0f;
+                if (offLimb != null) {
+                    offLimbY = offLimb.y;
+                    offLimb.y += 10000.0f;
+                }
+                StoredSlotState slotState = mirrorStoredStack(entity, slotName, i, stack);
+                SlotReference ref = slotState != null ? slotState.container().createReference(i) : SlotReference.of(entity, slotName, i);
+                try {
+                    renderer.render(stack, ref, poseStack, model, buffer, packedLight,
+                        0.0f, 0.0f, partialTick, 0.0f, 0.0f, 0.0f);
+                } catch (Exception e) {
+                    // Swallow rendering errors for individual accessories.
+                } finally {
+                    if (slotState != null) slotState.restore();
+                    if (offLimb != null) offLimb.y = offLimbY;
+                }
+            }
+        }
+    }
+
+    private static Set<String> storedSlotNames(RagdollPartBlockEntity blockEntity) {
+        Set<String> slotNames = new LinkedHashSet<>();
+        slotNames.addAll(blockEntity.getAccessoriesItems().keySet());
+        slotNames.addAll(blockEntity.getAccessoriesCosmeticItems().keySet());
+        return slotNames;
+    }
+
+    @Nullable
+    private static StoredSlotState mirrorStoredStack(LivingEntity entity, String slotName, int index, ItemStack stack) {
+        AccessoriesCapability cap = AccessoriesCapability.get(entity);
+        if (cap == null) return null;
+
+        AccessoriesContainer container = cap.getContainers().get(slotName);
+        if (container == null || index < 0 || index >= container.getSize()) return null;
+
+        ItemStack previous = container.getAccessories().getItem(index).copy();
+        container.getAccessories().setItem(index, stack.copy());
+        return new StoredSlotState(container, index, previous);
+    }
+
+    private record StoredSlotState(AccessoriesContainer container, int index, ItemStack previous) {
+        void restore() {
+            container.getAccessories().setItem(index, previous);
+        }
+    }
+
+    private static ItemStack storedEffectiveStack(List<ItemStack> cosmetics, int index, ItemStack actual) {
+        if (index < cosmetics.size()) {
+            ItemStack cosmetic = cosmetics.get(index);
+            if (!cosmetic.isEmpty()) return cosmetic;
+        }
+        return actual;
+    }
+
+    private static ItemStack storedStack(List<ItemStack> stacks, int index) {
+        return index < stacks.size() ? stacks.get(index) : ItemStack.EMPTY;
+    }
+
+    private static boolean storedShouldRender(RagdollPartBlockEntity blockEntity, String slotName, int index) {
+        List<Boolean> options = blockEntity.getAccessoriesRenderOptions().get(slotName);
+        return options == null || index >= options.size() || Boolean.TRUE.equals(options.get(index));
+    }
+
+    static void render(
+        BodyPart bodyPart,
+        LivingEntity entity,
+        RenderLayerParent<RagdollDollEntity, PlayerModel<RagdollDollEntity>> parent,
+        PoseStack poseStack,
+        MultiBufferSource buffer,
+        int packedLight,
+        float partialTick
+    ) {
+        AccessoriesCapability cap = AccessoriesCapability.get(entity);
+        if (cap == null) return;
+
+        PlayerModel<RagdollDollEntity> model = parent.getModel();
+        ModelPart offLimb = oppositeLimb(bodyPart, model);
+
+        for (Map.Entry<String, ? extends AccessoriesContainer> entry : cap.getContainers().entrySet()) {
+            String slotName = entry.getKey();
+            // Armor containers are handled through the vanilla armor layers
+            // via the cosmetic equipment override.
+            if (ArmorSlotTypes.isArmorType(slotName)) continue;
+
+            AccessoriesContainer container = entry.getValue();
+
+            for (int i = 0; i < container.getSize(); i++) {
+                ItemStack stack = container.getAccessories().getItem(i);
+                ItemStack cosmetic = container.getCosmeticAccessories().getItem(i);
+                if (!cosmetic.isEmpty()) stack = cosmetic;
+
+                if (stack.isEmpty()) continue;
+
+                AccessoryRenderer renderer = AccessoriesRendererRegistry.getRenderer(stack);
+                if (renderer.isEmpty() || !renderer.shouldRender(container.shouldRender(i))) continue;
+
+                float offLimbY = 0.0f;
+                if (offLimb != null) {
+                    offLimbY = offLimb.y;
+                    offLimb.y += 10000.0f;
+                }
+
+                SlotReference ref = container.createReference(i);
+                try {
+                    renderer.render(
+                        stack, ref, poseStack, model, buffer, packedLight,
+                        0.0f, 0.0f, partialTick, 0.0f, 0.0f, 0.0f
+                    );
+                } catch (Exception e) {
+                    // Swallow rendering errors for individual accessories.
+                } finally {
+                    if (offLimb != null) {
+                        offLimb.y = offLimbY;
+                    }
+                }
+            }
+        }
+    }
+
+    // Modification of PlayerRenderHandler (from CosmeticArmorReworked)
+    // Original source code: https://github.com/zzik2/CosmeticArmorReworkedForked/blob/master/common/src/main/java/lain/mods/cos/impl/client/PlayerRenderHandler.java
+    //
+    // Modified to run using ragdolls instead of Players
+    public enum RagdollRenderHandler {;
+        private final LoadingCache<Object, Deque<Runnable>> cache = CacheBuilder.newBuilder().weakKeys()
+                .build(new CacheLoader<Object, Deque<Runnable>>() {
+
+                    @Override
+                    public Deque<Runnable> load(Object key) throws Exception {
+                        return new ArrayDeque<>();
+                    }
+
+                });
+
+        private final LoadingCache<Object, ItemStack[]> cosArmorCache = CacheBuilder.newBuilder().weakKeys()
+                .build(new CacheLoader<Object, ItemStack[]>() {
+
+                    @Override
+                    public ItemStack[] load(Object key) throws Exception {
+                        return new ItemStack[4];
+                    }
+
+                });
+
+        public void handlePreRenderPlayer(Player player) {
+            Deque<Runnable> queue = cache.getUnchecked(player);
+            restoreItems(queue);
+            NonNullList<ItemStack> armor = player.getInventory().armor;
+
+            for (int i = 0; i < armor.size(); i++) {
+                int slot = i;
+                ItemStack stack = armor.get(slot);
+                queue.add(() -> armor.set(slot, stack));
+            }
+
+            if (PlayerRenderHandler.Disabled)
+                return;
+
+            InventoryCosArmor invCosArmor = ModObjects.invMan.getCosArmorInventoryClient(player.getUUID());
+
+            if (ModConfigs.getCosArmorStackRendering()) {
+                ItemStack[] cosArmor = cosArmorCache.getUnchecked(player);
+                for (int i = 0; i < armor.size(); i++) {
+                    if (invCosArmor.isSkinArmor(i)) {
+                        cosArmor[i] = null;
+                    } else {
+                        ItemStack cosStack = invCosArmor.getStackInSlot(i);
+                        cosArmor[i] = cosStack.isEmpty() ? null : cosStack.copy();
+                    }
+                }
+            } else {
+                ItemStack stack;
+                for (int i = 0; i < armor.size(); i++) {
+                    if (invCosArmor.isSkinArmor(i))
+                        armor.set(i, ItemStack.EMPTY);
+                    else if (!(stack = invCosArmor.getStackInSlot(i)).isEmpty())
+                        armor.set(i, stack);
+                }
+            }
+        }
+
+        public void handlePostRenderPlayer(Player player) {
+            restoreItems(cache.getUnchecked(player));
+        }
+
+        public void handlePreRenderPlayerCanceled(Player player) {
+            restoreItems(cache.getUnchecked(player));
+        }
+
+        public ItemStack[] getCosArmorForStackRendering(Player player) {
+            if (!ModConfigs.getCosArmorStackRendering() || PlayerRenderHandler.Disabled)
+                return null;
+            return cosArmorCache.getUnchecked(player);
+        }
+
+        private void restoreItems(Deque<Runnable> queue) {
+            Runnable runnable;
+            while ((runnable = queue.poll()) != null) {
+                try {
+                    runnable.run();
+                } catch (Throwable e) {
+                    ModObjects.logger.error("Failed in restoring client player items", e);
+                }
+            }
+        }
+
+    }
+}

--- a/src/main/java/dev/leo/sableplayerragdoll/neoforge/client/CosArmorRenderHelper.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/neoforge/client/CosArmorRenderHelper.java
@@ -241,7 +241,6 @@ final class CosArmorRenderHelper {
 
                 });
 
-        // todo: implement isSkinArmor(slot) into cosmeticArmorsRenderOptions
         // Added armor param because I dont feel like getting the armor straight from the entity
         public void handlePreRenderPlayer(RagdollPartBlockEntity ragdoll, ItemStack armor) {
             Deque<Runnable> queue = cache.getUnchecked(ragdoll);

--- a/src/main/java/dev/leo/sableplayerragdoll/neoforge/client/CosArmorRenderHelper.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/neoforge/client/CosArmorRenderHelper.java
@@ -47,11 +47,8 @@ final class CosArmorRenderHelper {
 
     @Nullable
     static ItemStack storedCosmeticArmorOverride(RagdollPartBlockEntity blockEntity, EquipmentSlot slot) {
-        SlotTypeReference reference = ArmorSlotTypes.getReferenceFromSlot(slot);
-        if (reference == null) return null;
-        String slotName = reference.slotName();
-        if (!storedShouldRender(blockEntity, slotName, 0)) return ItemStack.EMPTY;
-        List<ItemStack> cosmeticItems = blockEntity.getAccessoriesCosmeticItems().get(slotName);
+        if (!storedShouldRender(blockEntity, "main", 0)) return ItemStack.EMPTY;
+        List<ItemStack> cosmeticItems = blockEntity.getCosmeticArmorItems().get("main");
         if (cosmeticItems == null || cosmeticItems.isEmpty()) return null;
         ItemStack item = cosmeticItems.get(0);
         return item.isEmpty() ? null : item;
@@ -113,6 +110,9 @@ final class CosArmorRenderHelper {
 
         var invCosArmor = blockEntity.getCosmeticArmorItems().get("main");
 
+        if (invCosArmor == null || invCosArmor.isEmpty())
+            return;
+
         if (blockEntity.getCosmeticArmorsRenderOptions().get("main").get(slot))
             return;
 
@@ -128,11 +128,13 @@ final class CosArmorRenderHelper {
 
         try {
             ((Player)entity).getInventory().armor.set(slot, cosStack);
-            if (layer instanceof HumanoidArmorLayerAccessor accessor) {
-                accessor.renderPlayerArmor(poseStack, buffer, entity, equipmentSlot, packedLight, accessor.accessPlayerModel(equipmentSlot));
-            }
+            //if (layer instanceof HumanoidArmorLayerAccessor accessor) {
+            ((HumanoidArmorLayerAccessor)layer).renderPlayerArmor(poseStack, buffer, entity, equipmentSlot, packedLight, ((HumanoidArmorLayerAccessor)layer).accessPlayerModel(equipmentSlot));
+            //}
         } finally {
             ((Player)entity).getInventory().armor.set(slot, originalStack);
+            // attempted fix?
+            ((HumanoidArmorLayerAccessor)layer).renderPlayerArmor(poseStack, buffer, entity, equipmentSlot, packedLight, ((HumanoidArmorLayerAccessor)layer).accessPlayerModel(equipmentSlot));
         }
     }
 
@@ -210,7 +212,7 @@ final class CosArmorRenderHelper {
     }
 
     private static boolean storedShouldRender(RagdollPartBlockEntity blockEntity, String slotName, int index) {
-        List<Boolean> options = blockEntity.getAccessoriesRenderOptions().get(slotName);
+        List<Boolean> options = blockEntity.getCosmeticArmorsRenderOptions().get(slotName);
         return options == null || index >= options.size() || Boolean.TRUE.equals(options.get(index));
     }
 }

--- a/src/main/java/dev/leo/sableplayerragdoll/neoforge/client/CosArmorRenderHelper.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/neoforge/client/CosArmorRenderHelper.java
@@ -7,6 +7,8 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import dev.leo.sableplayerragdoll.block.entity.RagdollPartBlockEntity;
 import dev.leo.sableplayerragdoll.block.entity.RagdollPartBlockEntity.BodyPart;
 import dev.leo.sableplayerragdoll.entity.RagdollDollEntity;
+import dev.leo.sableplayerragdoll.neoforge.mixin.HumanoidArmorLayerAccessor;
+import dev.leo.sableplayerragdoll.neoforge.mixin.LivingEntityRendererAccessor;
 import io.wispforest.accessories.api.AccessoriesCapability;
 import io.wispforest.accessories.api.AccessoriesContainer;
 import io.wispforest.accessories.api.client.AccessoriesRendererRegistry;
@@ -21,10 +23,15 @@ import lain.mods.cos.impl.client.InventoryManagerClient;
 import lain.mods.cos.impl.client.PlayerRenderHandler;
 import lain.mods.cos.impl.inventory.InventoryCosArmor;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.model.HumanoidArmorModel;
 import net.minecraft.client.model.PlayerModel;
+import net.minecraft.client.model.geom.ModelLayers;
 import net.minecraft.client.model.geom.ModelPart;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.EntityRenderer;
 import net.minecraft.client.renderer.entity.RenderLayerParent;
+import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer;
+import net.minecraft.client.renderer.entity.layers.RenderLayer;
 import net.minecraft.core.NonNullList;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
@@ -72,6 +79,63 @@ final class CosArmorRenderHelper {
         };
     }
 
+    private static <T extends RenderLayer<?, ?>> T getLayer(EntityRenderer<? extends Player> playerRenderer) {
+        var accessor = (LivingEntityRendererAccessor)playerRenderer;
+        for (var layer : accessor.getLayers()) {
+            if (layer.getClass().isInstance(layer)) {
+                return (T)layer.getClass().cast(layer);
+            }
+        }
+        return null;
+    }
+
+    private static void renderSlot(
+            int slot,
+            BodyPart bodyPart,
+            RagdollPartBlockEntity blockEntity,
+            LivingEntity entity,
+            RenderLayerParent<RagdollDollEntity, PlayerModel<RagdollDollEntity>> parent,
+            PoseStack poseStack,
+            MultiBufferSource buffer,
+            int packedLight,
+            float partialTick,
+            EntityRenderer<? extends Player> playerRenderer) {
+
+        var equipmentSlot = switch (slot) {
+            case 0 -> EquipmentSlot.FEET;
+            case 1 -> EquipmentSlot.LEGS;
+            case 2 -> EquipmentSlot.CHEST;
+            case 3 -> EquipmentSlot.HEAD;
+            default -> null;
+        };
+
+        if (equipmentSlot == null) return;
+
+        var invCosArmor = blockEntity.getCosmeticArmorItems().get("main");
+
+        if (blockEntity.getCosmeticArmorsRenderOptions().get("main").get(slot))
+            return;
+
+        HumanoidArmorLayer<?,?,?> layer = getLayer(playerRenderer);
+
+        ItemStack cosStack = invCosArmor.get(slot);
+        if (cosStack.isEmpty())
+            return;
+
+        ItemStack originalStack = entity.getItemBySlot(equipmentSlot);
+        if (ItemStack.isSameItemSameComponents(originalStack, cosStack))
+            return;
+
+        try {
+            ((Player)entity).getInventory().armor.set(slot, cosStack);
+            if (layer instanceof HumanoidArmorLayerAccessor accessor) {
+                accessor.renderPlayerArmor(poseStack, buffer, entity, equipmentSlot, packedLight, accessor.accessPlayerModel());
+            }
+        } finally {
+            ((Player)entity).getInventory().armor.set(slot, originalStack);
+        }
+    }
+
     static void renderFromStored(
         BodyPart bodyPart,
         RagdollPartBlockEntity blockEntity,
@@ -80,39 +144,29 @@ final class CosArmorRenderHelper {
         PoseStack poseStack,
         MultiBufferSource buffer,
         int packedLight,
-        float partialTick
+        float partialTick,
+        EntityRenderer<? extends Player> playerRenderer
     ) {
-        PlayerModel<RagdollDollEntity> model = parent.getModel();
-        ModelPart offLimb = oppositeLimb(bodyPart, model);
+        if (!ModConfigs.getCosArmorStackRendering())
+            return;
 
-        for (String slotName : storedSlotNames(blockEntity)) {
-            if (ArmorSlotTypes.isArmorType(slotName)) continue;
-            List<ItemStack> stacks = blockEntity.getAccessoriesItems().getOrDefault(slotName, List.of());
-            List<ItemStack> cosmetics = blockEntity.getAccessoriesCosmeticItems().getOrDefault(slotName, List.of());
-            int slots = Math.max(stacks.size(), cosmetics.size());
-            for (int i = 0; i < slots; i++) {
-                if (!storedShouldRender(blockEntity, slotName, i)) continue;
-                ItemStack stack = storedEffectiveStack(cosmetics, i, storedStack(stacks, i));
-                if (stack.isEmpty()) continue;
-                AccessoryRenderer renderer = AccessoriesRendererRegistry.getRenderer(stack);
-                if (renderer.isEmpty() || !renderer.shouldRender(true)) continue;
+        if (PlayerRenderHandler.Disabled)
+            return;
 
-                float offLimbY = 0.0f;
-                if (offLimb != null) {
-                    offLimbY = offLimb.y;
-                    offLimb.y += 10000.0f;
-                }
-                StoredSlotState slotState = mirrorStoredStack(entity, slotName, i, stack);
-                SlotReference ref = slotState != null ? slotState.container().createReference(i) : SlotReference.of(entity, slotName, i);
-                try {
-                    renderer.render(stack, ref, poseStack, model, buffer, packedLight,
-                        0.0f, 0.0f, partialTick, 0.0f, 0.0f, 0.0f);
-                } catch (Exception e) {
-                    // Swallow rendering errors for individual accessories.
-                } finally {
-                    if (slotState != null) slotState.restore();
-                    if (offLimb != null) offLimb.y = offLimbY;
-                }
+        if (!(playerRenderer instanceof LivingEntityRendererAccessor))
+            return;
+
+        // I know this code is bad, I just dont know a better way to do it.
+        switch (bodyPart) {
+            case HEAD ->  {
+                renderSlot(3, bodyPart, blockEntity, entity, parent, poseStack, buffer, packedLight, partialTick, playerRenderer);
+            }
+            case TORSO, LEFT_ARM, RIGHT_ARM ->  {
+                renderSlot(2, bodyPart, blockEntity, entity, parent, poseStack, buffer, packedLight, partialTick, playerRenderer);
+            }
+            case LEFT_LEG, RIGHT_LEG -> {
+                renderSlot(1, bodyPart, blockEntity, entity, parent, poseStack, buffer, packedLight, partialTick, playerRenderer);
+                renderSlot(0, bodyPart, blockEntity, entity, parent, poseStack, buffer, packedLight, partialTick, playerRenderer);
             }
         }
     }
@@ -158,144 +212,5 @@ final class CosArmorRenderHelper {
     private static boolean storedShouldRender(RagdollPartBlockEntity blockEntity, String slotName, int index) {
         List<Boolean> options = blockEntity.getAccessoriesRenderOptions().get(slotName);
         return options == null || index >= options.size() || Boolean.TRUE.equals(options.get(index));
-    }
-
-    static void render(
-        BodyPart bodyPart,
-        LivingEntity entity,
-        RenderLayerParent<RagdollDollEntity, PlayerModel<RagdollDollEntity>> parent,
-        PoseStack poseStack,
-        MultiBufferSource buffer,
-        int packedLight,
-        float partialTick
-    ) {
-        AccessoriesCapability cap = AccessoriesCapability.get(entity);
-        if (cap == null) return;
-
-        PlayerModel<RagdollDollEntity> model = parent.getModel();
-        ModelPart offLimb = oppositeLimb(bodyPart, model);
-
-        for (Map.Entry<String, ? extends AccessoriesContainer> entry : cap.getContainers().entrySet()) {
-            String slotName = entry.getKey();
-            // Armor containers are handled through the vanilla armor layers
-            // via the cosmetic equipment override.
-            if (ArmorSlotTypes.isArmorType(slotName)) continue;
-
-            AccessoriesContainer container = entry.getValue();
-
-            for (int i = 0; i < container.getSize(); i++) {
-                ItemStack stack = container.getAccessories().getItem(i);
-                ItemStack cosmetic = container.getCosmeticAccessories().getItem(i);
-                if (!cosmetic.isEmpty()) stack = cosmetic;
-
-                if (stack.isEmpty()) continue;
-
-                AccessoryRenderer renderer = AccessoriesRendererRegistry.getRenderer(stack);
-                if (renderer.isEmpty() || !renderer.shouldRender(container.shouldRender(i))) continue;
-
-                float offLimbY = 0.0f;
-                if (offLimb != null) {
-                    offLimbY = offLimb.y;
-                    offLimb.y += 10000.0f;
-                }
-
-                SlotReference ref = container.createReference(i);
-                try {
-                    renderer.render(
-                        stack, ref, poseStack, model, buffer, packedLight,
-                        0.0f, 0.0f, partialTick, 0.0f, 0.0f, 0.0f
-                    );
-                } catch (Exception e) {
-                    // Swallow rendering errors for individual accessories.
-                } finally {
-                    if (offLimb != null) {
-                        offLimb.y = offLimbY;
-                    }
-                }
-            }
-        }
-    }
-
-    // Modification of PlayerRenderHandler (from CosmeticArmorReworked)
-    // Original source code: https://github.com/zzik2/CosmeticArmorReworkedForked/blob/master/common/src/main/java/lain/mods/cos/impl/client/PlayerRenderHandler.java
-    //
-    // Modified to run using ragdolls instead of Players
-    public enum RagdollRenderHandler {;
-        private final LoadingCache<Object, Deque<Runnable>> cache = CacheBuilder.newBuilder().weakKeys()
-                .build(new CacheLoader<Object, Deque<Runnable>>() {
-
-                    @Override
-                    public Deque<Runnable> load(Object key) throws Exception {
-                        return new ArrayDeque<>();
-                    }
-
-                });
-
-        private final LoadingCache<Object, ItemStack[]> cosArmorCache = CacheBuilder.newBuilder().weakKeys()
-                .build(new CacheLoader<Object, ItemStack[]>() {
-
-                    @Override
-                    public ItemStack[] load(Object key) throws Exception {
-                        return new ItemStack[4];
-                    }
-
-                });
-
-        // Added armor param because I dont feel like getting the armor straight from the entity
-        public void handlePreRenderPlayer(RagdollPartBlockEntity ragdoll, ItemStack armor) {
-            Deque<Runnable> queue = cache.getUnchecked(ragdoll);
-            restoreItems(queue);
-
-            if (PlayerRenderHandler.Disabled)
-                return;
-
-            InventoryCosArmor invCosArmor = ModObjects.invMan.getCosArmorInventoryClient(ragdoll.());
-
-            if (ModConfigs.getCosArmorStackRendering()) {
-                ItemStack[] cosArmor = cosArmorCache.getUnchecked(ragdoll);
-                for (int i = 0; i < armor.size(); i++) {
-                    if (invCosArmor.isSkinArmor(i)) {
-                        cosArmor[i] = null;
-                    } else {
-                        ItemStack cosStack = invCosArmor.getStackInSlot(i);
-                        cosArmor[i] = cosStack.isEmpty() ? null : cosStack.copy();
-                    }
-                }
-            } else {
-                ItemStack stack;
-                for (int i = 0; i < armor.size(); i++) {
-                    if (invCosArmor.isSkinArmor(i))
-                        armor.set(i, ItemStack.EMPTY);
-                    else if (!(stack = invCosArmor.getStackInSlot(i)).isEmpty())
-                        armor.set(i, stack);
-                }
-            }
-        }
-
-        public void handlePostRenderPlayer(Player player) {
-            restoreItems(cache.getUnchecked(player));
-        }
-
-        public void handlePreRenderPlayerCanceled(Player player) {
-            restoreItems(cache.getUnchecked(player));
-        }
-
-        public ItemStack[] getCosArmorForStackRendering(Player player) {
-            if (!ModConfigs.getCosArmorStackRendering() || PlayerRenderHandler.Disabled)
-                return null;
-            return cosArmorCache.getUnchecked(player);
-        }
-
-        private void restoreItems(Deque<Runnable> queue) {
-            Runnable runnable;
-            while ((runnable = queue.poll()) != null) {
-                try {
-                    runnable.run();
-                } catch (Throwable e) {
-                    ModObjects.logger.error("Failed in restoring client player items", e);
-                }
-            }
-        }
-
     }
 }

--- a/src/main/java/dev/leo/sableplayerragdoll/neoforge/client/CosArmorRenderHelper.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/neoforge/client/CosArmorRenderHelper.java
@@ -241,24 +241,19 @@ final class CosArmorRenderHelper {
 
                 });
 
-        public void handlePreRenderPlayer(Player player) {
-            Deque<Runnable> queue = cache.getUnchecked(player);
+        // todo: implement isSkinArmor(slot) into cosmeticArmorsRenderOptions
+        // Added armor param because I dont feel like getting the armor straight from the entity
+        public void handlePreRenderPlayer(RagdollPartBlockEntity ragdoll, ItemStack armor) {
+            Deque<Runnable> queue = cache.getUnchecked(ragdoll);
             restoreItems(queue);
-            NonNullList<ItemStack> armor = player.getInventory().armor;
-
-            for (int i = 0; i < armor.size(); i++) {
-                int slot = i;
-                ItemStack stack = armor.get(slot);
-                queue.add(() -> armor.set(slot, stack));
-            }
 
             if (PlayerRenderHandler.Disabled)
                 return;
 
-            InventoryCosArmor invCosArmor = ModObjects.invMan.getCosArmorInventoryClient(player.getUUID());
+            InventoryCosArmor invCosArmor = ModObjects.invMan.getCosArmorInventoryClient(ragdoll.());
 
             if (ModConfigs.getCosArmorStackRendering()) {
-                ItemStack[] cosArmor = cosArmorCache.getUnchecked(player);
+                ItemStack[] cosArmor = cosArmorCache.getUnchecked(ragdoll);
                 for (int i = 0; i < armor.size(); i++) {
                     if (invCosArmor.isSkinArmor(i)) {
                         cosArmor[i] = null;

--- a/src/main/java/dev/leo/sableplayerragdoll/neoforge/client/RagdollPartBlockEntityRenderer.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/neoforge/client/RagdollPartBlockEntityRenderer.java
@@ -203,7 +203,7 @@ public final class RagdollPartBlockEntityRenderer implements BlockEntityRenderer
          }
       }
       if (ModList.get().isLoaded("cosmeticarmorreworkedforked")) {
-         if (blockEntity.hasAccessoriesItems()) {
+         if (blockEntity.hasCosmeticArmor()) {
             CosArmorRenderHelper.renderFromStored(bodyPart, blockEntity, entity, this, poseStack, buffer, packedLight, partialTick, playerRenderer);
          }
       }

--- a/src/main/java/dev/leo/sableplayerragdoll/neoforge/client/RagdollPartBlockEntityRenderer.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/neoforge/client/RagdollPartBlockEntityRenderer.java
@@ -120,6 +120,7 @@ public final class RagdollPartBlockEntityRenderer implements BlockEntityRenderer
       var playerRenderer = minecraft.getEntityRenderDispatcher().getSkinMap().get(slim ? PlayerSkin.Model.SLIM : PlayerSkin.Model.WIDE);
 
       boolean accessoriesLoaded = ModList.get().isLoaded("accessories");
+      boolean cosmeticArmorsLoaded = ModList.get().isLoaded("cosmeticarmorreworkedforked");
 
       if (playerRenderer instanceof LivingEntityRendererAccessor accessor) {
          boolean wasInvisible = entity.isInvisible();
@@ -130,10 +131,16 @@ public final class RagdollPartBlockEntityRenderer implements BlockEntityRenderer
          for (EquipmentSlot slot : EquipmentSlot.values()) {
             oldItems[slot.ordinal()] = entity.getItemBySlot(slot);
             ItemStack candidate = blockEntity.itemBySlot(slot);
+
             if (accessoriesLoaded && slot.getType() == EquipmentSlot.Type.HUMANOID_ARMOR && blockEntity.hasAccessoriesItems()) {
                ItemStack cosmetic = AccessoriesRenderHelper.storedCosmeticArmorOverride(blockEntity, slot);
                if (cosmetic != null) candidate = cosmetic;
             }
+            if (cosmeticArmorsLoaded && slot.getType() == EquipmentSlot.Type.HUMANOID_ARMOR && blockEntity.hasCosmeticArmor()) {
+               ItemStack cosmetic = CosArmorRenderHelper.storedCosmeticArmorOverride(blockEntity, slot);
+               if (cosmetic != null) candidate = cosmetic;
+            }
+
             ItemStack toShow = slotsForPart(bodyPart).contains(slot) && !isArmorSlotBlockedForPart(bodyPart, slot, candidate)
                ? candidate : ItemStack.EMPTY;
             entity.setItemSlot(slot, toShow);

--- a/src/main/java/dev/leo/sableplayerragdoll/neoforge/client/RagdollPartBlockEntityRenderer.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/neoforge/client/RagdollPartBlockEntityRenderer.java
@@ -202,6 +202,11 @@ public final class RagdollPartBlockEntityRenderer implements BlockEntityRenderer
             AccessoriesRenderHelper.renderFromStored(bodyPart, blockEntity, entity, this, poseStack, buffer, packedLight, partialTick);
          }
       }
+      if (ModList.get().isLoaded("cosmeticarmorreworkedforked")) {
+         if (blockEntity.hasAccessoriesItems()) {
+            CosArmorRenderHelper.renderFromStored(bodyPart, blockEntity, entity, this, poseStack, buffer, packedLight, partialTick, playerRenderer);
+         }
+      }
       if (ModList.get().isLoaded("curios")) {
          if (blockEntity.hasCurioItems()) {
             CuriosRenderHelper.renderFromStored(bodyPart, blockEntity, entity, this, poseStack, buffer, packedLight, partialTick);

--- a/src/main/java/dev/leo/sableplayerragdoll/neoforge/mixin/HumanoidArmorLayerAccessor.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/neoforge/mixin/HumanoidArmorLayerAccessor.java
@@ -1,0 +1,16 @@
+package dev.leo.sableplayerragdoll.neoforge.mixin;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer;
+import net.minecraft.world.entity.EquipmentSlot;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(HumanoidArmorLayer.class)
+public interface HumanoidArmorLayerAccessor {
+    @Invoker("getArmorModel")
+    <A> A accessPlayerModel();
+    @Invoker("Lnet/minecraft/client/renderer/entity/layers/HumanoidArmorLayer;renderArmorPiece(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/entity/EquipmentSlot;ILnet/minecraft/client/model/HumanoidModel;)V")
+    <T, A> void renderPlayerArmor(PoseStack poseStack, MultiBufferSource bufferSource, T livingEntity, EquipmentSlot slot, int packedLight, A model);
+}

--- a/src/main/java/dev/leo/sableplayerragdoll/neoforge/mixin/HumanoidArmorLayerAccessor.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/neoforge/mixin/HumanoidArmorLayerAccessor.java
@@ -1,16 +1,18 @@
 package dev.leo.sableplayerragdoll.neoforge.mixin;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer;
 import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Invoker;
 
 @Mixin(HumanoidArmorLayer.class)
-public interface HumanoidArmorLayerAccessor {
+public interface HumanoidArmorLayerAccessor<T extends LivingEntity, M extends HumanoidModel<T>, A extends HumanoidModel<T>> {
     @Invoker("getArmorModel")
-    <A> A accessPlayerModel(EquipmentSlot slot);
-    @Invoker("Lnet/minecraft/client/renderer/entity/layers/HumanoidArmorLayer;renderArmorPiece(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/entity/EquipmentSlot;ILnet/minecraft/client/model/HumanoidModel;)V")
-    <T, A> void renderPlayerArmor(PoseStack poseStack, MultiBufferSource bufferSource, T livingEntity, EquipmentSlot slot, int packedLight, A model);
+    A accessPlayerModel(EquipmentSlot slot);
+    @Invoker("renderArmorPiece")
+    void renderPlayerArmor(PoseStack poseStack, MultiBufferSource bufferSource, T livingEntity, EquipmentSlot slot, int packedLight, A model);
 }

--- a/src/main/java/dev/leo/sableplayerragdoll/neoforge/mixin/HumanoidArmorLayerAccessor.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/neoforge/mixin/HumanoidArmorLayerAccessor.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.gen.Invoker;
 @Mixin(HumanoidArmorLayer.class)
 public interface HumanoidArmorLayerAccessor {
     @Invoker("getArmorModel")
-    <A> A accessPlayerModel();
+    <A> A accessPlayerModel(EquipmentSlot slot);
     @Invoker("Lnet/minecraft/client/renderer/entity/layers/HumanoidArmorLayer;renderArmorPiece(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/entity/EquipmentSlot;ILnet/minecraft/client/model/HumanoidModel;)V")
     <T, A> void renderPlayerArmor(PoseStack poseStack, MultiBufferSource bufferSource, T livingEntity, EquipmentSlot slot, int packedLight, A model);
 }

--- a/src/main/java/dev/leo/sableplayerragdoll/neoforge/mixin/HumanoidArmorLayerMixin.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/neoforge/mixin/HumanoidArmorLayerMixin.java
@@ -4,11 +4,16 @@ import dev.leo.sableplayerragdoll.block.entity.RagdollPartBlockEntity.BodyPart;
 import dev.leo.sableplayerragdoll.neoforge.client.RagdollPartBlockEntityRenderer;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.client.renderer.entity.layers.HumanoidArmorLayer;
+import net.minecraft.client.renderer.entity.layers.RenderLayer;
 import net.minecraft.world.entity.EquipmentSlot;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+import org.spongepowered.asm.mixin.gen.Invoker;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
 
 @Mixin(HumanoidArmorLayer.class)
 public class HumanoidArmorLayerMixin {
@@ -44,4 +49,5 @@ public class HumanoidArmorLayerMixin {
             default -> {}
         }
     }
+
 }

--- a/src/main/java/dev/leo/sableplayerragdoll/physics/RagdollCosArmorHelper.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/physics/RagdollCosArmorHelper.java
@@ -1,0 +1,106 @@
+package dev.leo.sableplayerragdoll.physics;
+
+import dev.leo.sableplayerragdoll.block.entity.RagdollPartBlockEntity;
+import lain.mods.cos.impl.ModObjects;
+import lain.mods.cos.impl.inventory.InventoryCosArmor;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.*;
+
+// All uses of the hash map with use "main" as the only key
+// because I would rather keep constancy than use cleaner code
+// as that would be annoying for the other contributors.
+final class RagdollCosArmorHelper {
+   private RagdollCosArmorHelper() {
+   }
+
+   static void applyToPart(RagdollPartBlockEntity part, Player player) {
+      CosArmorSnapshot snapshot = captureSnapshot(player, true);
+      snapshot.items().forEach(part::setCosmeticArmorItems);
+      snapshot.renderOptions().forEach(part::setCosmeticArmorRenderOptions);
+   }
+
+   static void applyFrom(ServerLevel level, UUID rootId, Player player) {
+      CosArmorSnapshot snapshot = captureSnapshot(player, true);
+      RagdollEquipmentHelper.applyToAllParts(level, rootId, be -> {
+         snapshot.items().forEach(be::setCosmeticArmorItems);
+         snapshot.renderOptions().forEach(be::setCosmeticArmorRenderOptions);
+      });
+   }
+
+   static Map<String, List<ItemStack>> capture(Player player) {
+      return captureSnapshot(player, false).items();
+   }
+
+   static CosArmorSnapshot captureSnapshot(Player player) {
+      return captureSnapshot(player, false);
+   }
+
+   private static CosArmorSnapshot captureSnapshot(Player player, boolean includeEmptySlots) {
+      var inv = ModObjects.invMan.getCosArmorInventory(player.getUUID());
+      if (inv == null) return CosArmorSnapshot.empty();
+
+      Map<String, List<ItemStack>> accessoriesItems = new LinkedHashMap<>();
+      Map<String, List<Boolean>> accessoriesRenderOptions = new LinkedHashMap<>();
+
+      List<ItemStack> items = items(inv, 4);
+      List<Boolean> renderOptions = renderOptions(inv);
+      if (includeEmptySlots || hasAnyStack(items)) {
+         accessoriesItems.put("main", items);
+         accessoriesRenderOptions.put("main", renderOptions);
+      }
+
+      return new CosArmorSnapshot(accessoriesItems, accessoriesRenderOptions);
+   }
+
+   private static List<ItemStack> items(InventoryCosArmor container, int size) {
+      List<ItemStack> items = new ArrayList<>(size);
+      for (int i = 0; i < size; i++) {
+         items.add(container.getItem(i).copy());
+      }
+      return items;
+   }
+
+   private static List<Boolean> renderOptions(InventoryCosArmor container) {
+      List<Boolean> options = new ArrayList<>(container.getSlots());
+      for (int i = 0; i < container.getSlots(); i++) {
+         options.add(container.isSkinArmor(i));
+      }
+      return options;
+   }
+
+   private static boolean hasAnyStack(List<ItemStack> items) {
+      return items.stream().anyMatch(stack -> !stack.isEmpty());
+   }
+
+   static long cosmeticArmorSignature(Player player) {
+      long hash = 1L;
+      CosArmorSnapshot snapshot = captureSnapshot(player, true);
+      for (Map.Entry<String, List<ItemStack>> entry : snapshot.items().entrySet()) {
+         hash = 31L * hash + entry.getKey().hashCode();
+         List<ItemStack> items = entry.getValue();
+         for (int i = 0; i < items.size(); i++) {
+            hash = 31L * hash + i;
+            hash = 31L * hash + stackSignature(items.get(i));
+            hash = 31L * hash + Boolean.hashCode(snapshot.renderOptions().getOrDefault(entry.getKey(), List.of()).size() > i && snapshot.renderOptions().get(entry.getKey()).get(i));
+         }
+      }
+      return hash;
+   }
+
+   private static long stackSignature(ItemStack stack) {
+      if (stack.isEmpty()) return 0L;
+      long hash = System.identityHashCode(stack.getItem());
+      hash = 31L * hash + stack.getCount();
+      hash = 31L * hash + stack.getComponents().hashCode();
+      return hash;
+   }
+
+   record CosArmorSnapshot(Map<String, List<ItemStack>> items, Map<String, List<Boolean>> renderOptions) {
+      static CosArmorSnapshot empty() {
+         return new CosArmorSnapshot(Map.of(), Map.of());
+      }
+   }
+}

--- a/src/main/java/dev/leo/sableplayerragdoll/physics/RagdollEquipmentHelper.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/physics/RagdollEquipmentHelper.java
@@ -29,6 +29,9 @@ final class RagdollEquipmentHelper {
       if (ModList.get().isLoaded("accessories")) {
          RagdollAccessoriesEquipmentHelper.applyToPart(part, player);
       }
+      if (ModList.get().isLoaded("cosmeticarmorreworkedforked")) {
+         RagdollCosArmorHelper.applyToPart(part, player);
+      }
    }
 
    static void applyFrom(ServerLevel level, UUID rootId, Player player) {

--- a/src/main/java/dev/leo/sableplayerragdoll/physics/RagdollEquipmentHelper.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/physics/RagdollEquipmentHelper.java
@@ -72,6 +72,11 @@ final class RagdollEquipmentHelper {
             accessoriesCosmeticItems = accessories.cosmeticItems();
             accessoriesRenderOptions = accessories.renderOptions();
          }
+         if (ModList.get().isLoaded("cosmeticarmorreworkedforked")) {
+            RagdollCosArmorHelper.CosArmorSnapshot armor = RagdollCosArmorHelper.captureSnapshot(player);
+            cosmeticArmorItems = armor.items();
+            cosmeticArmorRenderOptions = armor.renderOptions();
+         }
       }
 
       return new RagdollEquipmentSnapshot(

--- a/src/main/java/dev/leo/sableplayerragdoll/physics/RagdollEquipmentHelper.java
+++ b/src/main/java/dev/leo/sableplayerragdoll/physics/RagdollEquipmentHelper.java
@@ -48,6 +48,8 @@ final class RagdollEquipmentHelper {
       Map<String, List<ItemStack>> accessoriesItems = Map.of();
       Map<String, List<ItemStack>> accessoriesCosmeticItems = Map.of();
       Map<String, List<Boolean>> accessoriesRenderOptions = Map.of();
+      Map<String, List<ItemStack>> cosmeticArmorItems = Map.of();
+      Map<String, List<Boolean>> cosmeticArmorRenderOptions = Map.of();
 
       if (resolved == RagdollEquipmentScope.ALL || resolved == RagdollEquipmentScope.VANILLA) {
          EnumMap<EquipmentSlot, ItemStack> vanilla = new EnumMap<>(EquipmentSlot.class);
@@ -72,7 +74,12 @@ final class RagdollEquipmentHelper {
          }
       }
 
-      return new RagdollEquipmentSnapshot(vanillaItems, curioItems, curioCosmeticItems, curioRenderOptions, accessoriesItems, accessoriesCosmeticItems, accessoriesRenderOptions);
+      return new RagdollEquipmentSnapshot(
+              vanillaItems,
+              curioItems, curioCosmeticItems, curioRenderOptions,
+              accessoriesItems, accessoriesCosmeticItems, accessoriesRenderOptions,
+              cosmeticArmorItems, cosmeticArmorRenderOptions
+      );
    }
 
    static void applySnapshot(ServerLevel level, UUID rootId, RagdollEquipmentSnapshot snapshot) {

--- a/src/main/resources/sable_player_ragdoll.neoforge.mixins.json
+++ b/src/main/resources/sable_player_ragdoll.neoforge.mixins.json
@@ -16,6 +16,7 @@
     "RagdollFirstPersonEyeMixin",
     "EntitySubLevelRotationHelperMixin",
     "HumanoidArmorLayerMixin",
+    "HumanoidArmorLayerAccessor",
     "HumanoidModelMixin",
     "LivingEntityRendererAccessor",
     "LivingEntityRendererMixin",


### PR DESCRIPTION
This is specifically targeting a [fork of cosmetic armor reworked](https://modrinth.com/mod/cosmetic-armor-reworked-forked) that has more customization and is on Modrinth instead of Curseforge.

Some things to note (there may be more after more progress)
- I wasn't able to easily find a neat version id for the neoforge version of this mod, as the version number ("1.21.1-0.0.4") only targets the fabric version, instead of there being a "1.21.1-0.0.4-fabric" and "1.21.1-0.0.4-neoforge" it is "1.21.1-0.0.4" for fabric and ??? for neoforge.
- The fork adds the ability to render the cosmetic armor slot and normal armor slot at the same time.

I also started this after seeing a github issue for the fork specifically asking for ragdoll compat, which I was thinking would be nice for me and my friends' server, as we already are using both of these mods.